### PR TITLE
Events

### DIFF
--- a/com.coconut_palm_software.xscalawt/src/com/coconut_palm_software/xscalawt/XScalaWT.scala
+++ b/com.coconut_palm_software.xscalawt/src/com/coconut_palm_software/xscalawt/XScalaWT.scala
@@ -362,25 +362,32 @@ object XScalaWT {
   def addSelectionListener[T <: AddSelectionListener](l: SelectionListener) =
     (subject: T) => subject.addSelectionListener(l)
     
-  implicit def selectionFn2addSelectionListener[T <: AddSelectionListener](func: SelectionEvent => Any) =
+  implicit def onSelection[T <: AddSelectionListener](func: SelectionEvent => Any) =
     addSelectionListener[T](func)
+    
+  // can't be => Any, or we lose type inference
+  def onSelection[T <: AddSelectionListener](func: => Unit) =
+    addSelectionListener[T]((e: SelectionEvent) => func)
   
   implicit def func2SelectionListener(func: SelectionEvent => Any): SelectionListener =
-	new SelectionListenerForwarder(func)
+	  new SelectionListenerForwarder(func)
   
   // MouseListener-----------------------------------------------------------------
 
   private type AddMouseListener = { def addMouseListener(l : MouseListener) }
   
   private class MouseListenerForwarder(func: MouseEvent => Any) extends MouseAdapter {
-	override def mouseDown(e : MouseEvent) = func(e)
+	  override def mouseDown(e : MouseEvent) = func(e)
   }
 
   def addMouseListener[T <: AddMouseListener](l: MouseListener) = 
-	(subject:T) => subject.addMouseListener(l)
+	  (subject:T) => subject.addMouseListener(l)
   
-  implicit def mouseFunc2addMouseListener[T <: AddMouseListener](func: MouseEvent => Any) =
-	addMouseListener[T](func)
+  implicit def onMouseDown[T <: AddMouseListener](func: MouseEvent => Any) =
+	  addMouseListener[T](func)
+	  
+  def onMouseDown[T <: AddMouseListener](func: => Unit) =
+    addMouseListener[T]((e: MouseEvent) => func)
   
   implicit def func2MouseListener(func: MouseEvent => Any): MouseListener =
 	  new MouseListenerForwarder(func)
@@ -390,14 +397,17 @@ object XScalaWT {
   private type AddModifyListener = { def addModifyListener(l: ModifyListener) }
   
   def addModifyListener[T <: AddModifyListener](l: ModifyListener) =
-	(subject : T) => subject.addModifyListener(l)
+	  (subject : T) => subject.addModifyListener(l)
   
   private class ModifyListenerForwarder(func: ModifyEvent => Any) extends ModifyListener {
     override def modifyText(e: ModifyEvent) = func(e)
   }
   
-  implicit def modifyFn2addModifyListener[T <: AddModifyListener](func: ModifyEvent => Any) = 
-	addModifyListener[T](func)
+  implicit def onModify[T <: AddModifyListener](func: ModifyEvent => Any) = 
+	  addModifyListener[T](func)
+	  
+	def onModify[T <: AddModifyListener](func: => Unit) = 
+    addModifyListener[T]((e: ModifyEvent) => func)
   
   implicit def func2ModifyListener(func: ModifyEvent => Any): ModifyListener = 
     new ModifyListenerForwarder(func)
@@ -407,14 +417,17 @@ object XScalaWT {
   private type AddTraverseListener = { def addTraverseListener(l: TraverseListener) }
   
   def addTraverseListener[T <: AddTraverseListener](l: TraverseListener) =
-	(subject: T) => subject.addTraverseListener(l)
+	  (subject: T) => subject.addTraverseListener(l)
   
   private class TraverseListenerForwarder(func: TraverseEvent => Any) extends TraverseListener {
     override def keyTraversed(e : TraverseEvent) = func(e)
   }
   
-  implicit def modifyFn2addTraverseListener[T <: AddTraverseListener](func: TraverseEvent => Any) =
-	addTraverseListener[T](func)
+  implicit def onTraverse[T <: AddTraverseListener](func: TraverseEvent => Any) =
+	  addTraverseListener[T](func)
+	  
+	def onTraverse[T <: AddTraverseListener](func: => Unit) =
+    addTraverseListener[T]((e: TraverseEvent) => func)
   
   implicit def func2TraverseListener(func: TraverseEvent => Any): TraverseListener = 
     new TraverseListenerForwarder(func)

--- a/com.coconut_palm_software.xscalawt/src/com/coconut_palm_software/xscalawt/examples/LoginBox.scala
+++ b/com.coconut_palm_software.xscalawt/src/com/coconut_palm_software/xscalawt/examples/LoginBox.scala
@@ -59,11 +59,11 @@ object LoginBox {
 
         button("OK", 
           layoutData = new GridData(GridData.HORIZONTAL_ALIGN_FILL),
-          { e : SelectionEvent => println("OK") }
+          onSelection { println("OK") }
         ),
         button("Cancel", 
           layoutData = new GridData(GridData.HORIZONTAL_ALIGN_FILL),
-          { e : SelectionEvent => println("Cancel") }
+          onSelection { println("Cancel") }
         )
       ),
       

--- a/com.coconut_palm_software.xscalawt/src/com/coconut_palm_software/xscalawt/examples/progression/TemperatureScala4.scala
+++ b/com.coconut_palm_software.xscalawt/src/com/coconut_palm_software/xscalawt/examples/progression/TemperatureScala4.scala
@@ -21,7 +21,7 @@ class Temperature4(parent: Composite, style : Int) extends Composite(parent, sty
     text(fahrenheit = _),
     text(celcius = _),
  
-    button("Fareinheight => Celcius", {e : SelectionEvent => celcius.setText((5.0/9.0) * (fahrenheit - 32)) }),
+    button("Fareinheight => Celcius", onSelection {e => celcius.setText((5.0/9.0) * (fahrenheit - 32)) }),
     button("Celcius -> Fareinheight", {e : SelectionEvent => fahrenheit.setText((9.0/5.0) * celcius + 32) })
   )
 }


### PR DESCRIPTION
I've renamed existing implicits for better type inference (see changes in examples) and added support for all events in `org.eclipse.swt.events`. Hopefully there are no typos :) 

The bad part is that I get warnings like

```
[WARNING] /home/aromanov/workspace/XScalaWT/com.coconut_palm_software.xscalawt/src/com/coconut_palm_software/xscalawt/XScalaWT.scala:687: warning: parameterized overloaded implicit methods are not visible as view bounds
[INFO]   implicit def onPaint[T <: AddPaintListener](func: PaintEvent => Any) = 
[INFO]                ^
```

However, they shouldn't be used as view bounds anyway, so I don't consider it a major problem. To reduce noise, the methods should still be renamed or warnings suppressed (I asked about the correct value for @SuppressWarnings on the scala-user list).
