### PR TITLE
Change dependency name

### DIFF
--- a/com.coconut_palm_software.xscalawt/META-INF/MANIFEST.MF
+++ b/com.coconut_palm_software.xscalawt/META-INF/MANIFEST.MF
@@ -10,5 +10,6 @@ Require-Bundle: org.eclipse.swt,
  org.eclipse.core.databinding.beans,
  org.eclipse.core.databinding.property,
  org.eclipse.jface.databinding,
- org.eclipse.core.runtime
+ org.eclipse.core.runtime,
+ org.scala-ide.scala.library;bundle-version="2.8.0"
 Export-Package: com.coconut_palm_software.xscalawt

--- a/com.coconut_palm_software.xscalawt/META-INF/MANIFEST.MF.rap
+++ b/com.coconut_palm_software.xscalawt/META-INF/MANIFEST.MF.rap
@@ -4,7 +4,7 @@ Bundle-Name: XScalaWT
 Bundle-Vendor: Coconut Palm Software
 Bundle-SymbolicName: com.coconut_palm_software.xscalawt
 Bundle-Version: 1.0.0
-Require-Bundle: scala.library,
+Require-Bundle: org.scala-ide.scala.library;bundle-version="2.8.0",
  org.eclipse.core.databinding;bundle-version="1.1.0",
  org.eclipse.core.databinding.beans;bundle-version="1.1.0",
  org.eclipse.core.databinding.property;bundle-version="1.3.0",

--- a/com.coconut_palm_software.xscalawt/META-INF/MANIFEST.MF.swt
+++ b/com.coconut_palm_software.xscalawt/META-INF/MANIFEST.MF.swt
@@ -4,7 +4,7 @@ Bundle-Name: XScalaWT
 Bundle-Vendor: Coconut Palm Software
 Bundle-SymbolicName: com.coconut_palm_software.xscalawt
 Bundle-Version: 1.0.0
-Require-Bundle: scala.library,
+Require-Bundle: org.scala-ide.scala.library;bundle-version="2.8.0",
  org.eclipse.swt;bundle-version="3.4.0",
  org.eclipse.jface;bundle-version="3.4.0",
  org.eclipse.core.databinding;bundle-version="1.1.0",

--- a/com.coconut_palm_software.xscalawt/pom.xml
+++ b/com.coconut_palm_software.xscalawt/pom.xml
@@ -20,7 +20,7 @@
 		<sourceDirectory>src</sourceDirectory>
 		<plugins>
 			<plugin>
-				<groupId>org.sonatype.tycho</groupId>
+				<groupId>org.eclipse.tycho</groupId>
 				<artifactId>target-platform-configuration</artifactId>
 				<version>${tycho-version}</version>
 				<configuration>
@@ -29,8 +29,8 @@
 				</configuration>
 			</plugin>
 			<plugin>
-				<groupId>org.sonatype.tycho</groupId>
-				<artifactId>maven-osgi-compiler-plugin</artifactId>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>tycho-compiler-plugin</artifactId>
 				<version>${tycho-version}</version>
 				<configuration>
 					<excludeResources>

--- a/xscalawt.releng/pom.xml
+++ b/xscalawt.releng/pom.xml
@@ -11,7 +11,7 @@
 
 	<properties>
 		<scala.version>2.9.0-1</scala.version>
-		<tycho-version>0.11.0</tycho-version>
+		<tycho-version>0.12.0</tycho-version>
 		<maven-scala-plugin-version>2.14</maven-scala-plugin-version>
 		<encoding>UTF-8</encoding>
 	</properties>
@@ -65,7 +65,7 @@
 
 	<pluginRepositories>
 		<pluginRepository>
-			<id>org.sonatype.tycho</id>
+			<id>org.eclipse.tycho</id>
 			<name>Tycho snapshot repository</name>
 			<url>https://repository.sonatype.org/content/repositories/snapshots</url>
 			<snapshots>
@@ -86,7 +86,7 @@
 			<url>http://scala-tools.org/repo-snapshots</url>
 		</pluginRepository>
 	</pluginRepositories>
-	
+
 	<profiles>
 		<profile>
 			<id>scala-2.8.0</id>
@@ -380,17 +380,18 @@
 						</goals>
 					</execution>
 				</executions>
+				<version>${maven-scala-plugin-version}</version>
 			</plugin>
-			
+
 			<plugin>
-				<groupId>org.sonatype.tycho</groupId>
+				<groupId>org.eclipse.tycho</groupId>
 				<artifactId>tycho-maven-plugin</artifactId>
 				<version>${tycho-version}</version>
 				<extensions>true</extensions>
 			</plugin>
 
 			<plugin>
-				<groupId>org.sonatype.tycho</groupId>
+				<groupId>org.eclipse.tycho</groupId>
 				<artifactId>target-platform-configuration</artifactId>
 				<version>${tycho-version}</version>
 				<configuration>

--- a/xscalawt.releng/pom.xml
+++ b/xscalawt.releng/pom.xml
@@ -12,7 +12,7 @@
 	<properties>
 		<scala.version>2.9.0-1</scala.version>
 		<tycho-version>0.12.0</tycho-version>
-		<maven-scala-plugin-version>2.14</maven-scala-plugin-version>
+		<maven-scala-plugin-version>2.15.2</maven-scala-plugin-version>
 		<encoding>UTF-8</encoding>
 	</properties>
 

--- a/xscalawt.releng/pom.xml
+++ b/xscalawt.releng/pom.xml
@@ -35,6 +35,11 @@
 			<artifactId>scala-library</artifactId>
 			<version>${scala.version}</version>
 		</dependency>
+		<dependency>
+			<groupId>org.scala-ide</groupId>
+			<artifactId>org.scala-ide.scala.library</artifactId>
+			<version>${scala.version}</version>
+		</dependency>
 	</dependencies>
 
 	<repositories>
@@ -59,6 +64,15 @@
 			<url>http://scala-tools.org/repo-snapshots</url>
 			<snapshots>
 				<updatePolicy>daily</updatePolicy>
+			</snapshots>
+		</repository>
+		<repository>
+			<id>scala-osgi</id>
+			<name>Scala OSGi toolchain p2 repository</name>
+			<layout>p2</layout>
+			<url>http://download.scala-ide.org/scala-eclipse-toolchain-osgi-${scala.version}</url>
+			<snapshots>
+				<enabled>false</enabled>
 			</snapshots>
 		</repository>
 	</repositories>


### PR DESCRIPTION
I don't think there is a publicly available `scala.library` OSGi bundle, so I changed the dependency name in `MANIFEST.MF` to `org.scala-ide.scala.library`. Also changed to current versions of `maven-scala-plugin` and `tycho-maven-plugin`.
